### PR TITLE
fix find by name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.parallel=true
 makeevrserg.project.name=IRDBBackend
 makeevrserg.project.url=https://github.com/flipperdevices/IRDB-Backend
 makeevrserg.project.group=com.flipperdevices.ifrmvp.backend
-makeevrserg.project.version.string=0.6.0
+makeevrserg.project.version.string=0.7.0
 makeevrserg.project.description=Api for IfrSample
 makeevrserg.project.developers=makeevrserg|Makeev Roman|makeevrserg@gmail.com
 # Java

--- a/modules/database/src/main/kotlin/com/flipperdevices/ifrmvp/backend/db/signal/di/factory/SignalDatabaseFactory.kt
+++ b/modules/database/src/main/kotlin/com/flipperdevices/ifrmvp/backend/db/signal/di/factory/SignalDatabaseFactory.kt
@@ -7,6 +7,7 @@ import com.flipperdevices.ifrmvp.backend.db.signal.table.CategoryTable
 import com.flipperdevices.ifrmvp.backend.db.signal.table.InfraredFileTable
 import com.flipperdevices.ifrmvp.backend.db.signal.table.InfraredFileToSignalTable
 import com.flipperdevices.ifrmvp.backend.db.signal.table.SignalKeyTable
+import com.flipperdevices.ifrmvp.backend.db.signal.table.SignalNameAliasTable
 import com.flipperdevices.ifrmvp.backend.db.signal.table.SignalTable
 import com.flipperdevices.ifrmvp.backend.db.signal.table.UiPresetTable
 import com.flipperdevices.ifrmvp.backend.envkonfig.model.DBConnection
@@ -32,6 +33,7 @@ internal class SignalDatabaseFactory(
                     CategoryTable,
                     InfraredFileTable,
                     InfraredFileToSignalTable,
+                    SignalNameAliasTable,
                     SignalTable,
                     SignalKeyTable,
                     UiPresetTable,

--- a/modules/database/src/main/kotlin/com/flipperdevices/ifrmvp/backend/db/signal/table/SignalNameAliasTable.kt
+++ b/modules/database/src/main/kotlin/com/flipperdevices/ifrmvp/backend/db/signal/table/SignalNameAliasTable.kt
@@ -1,0 +1,12 @@
+package com.flipperdevices.ifrmvp.backend.db.signal.table
+
+import org.jetbrains.exposed.dao.id.LongIdTable
+
+object SignalNameAliasTable : LongIdTable("SIGNAL_NAME_ALIAS") {
+    val signalId = reference("signal_id", SignalTable)
+    val signalName = text("signal_name")
+
+    init {
+        uniqueIndex(signalId, signalName)
+    }
+}

--- a/modules/database/src/main/kotlin/com/flipperdevices/ifrmvp/backend/db/signal/table/SignalTable.kt
+++ b/modules/database/src/main/kotlin/com/flipperdevices/ifrmvp/backend/db/signal/table/SignalTable.kt
@@ -12,7 +12,6 @@ import org.jetbrains.exposed.dao.id.LongIdTable
 object SignalTable : LongIdTable("SIGNAL_TABLE") {
     val brandId = reference("brand_id", BrandTable)
 
-    val name = text("name")
     val type = text("type")
     val protocol = text("protocol").nullable()
     val address = text("address").nullable()

--- a/web-api/src/main/kotlin/com/flipperdevices/ifrmvp/backend/route/signal/presentation/SignalRouteRegistry.kt
+++ b/web-api/src/main/kotlin/com/flipperdevices/ifrmvp/backend/route/signal/presentation/SignalRouteRegistry.kt
@@ -6,6 +6,7 @@ import com.flipperdevices.ifrmvp.backend.db.signal.exception.TableDaoException
 import com.flipperdevices.ifrmvp.backend.db.signal.table.InfraredFileTable
 import com.flipperdevices.ifrmvp.backend.db.signal.table.InfraredFileToSignalTable
 import com.flipperdevices.ifrmvp.backend.db.signal.table.SignalKeyTable
+import com.flipperdevices.ifrmvp.backend.db.signal.table.SignalNameAliasTable
 import com.flipperdevices.ifrmvp.backend.db.signal.table.SignalTable
 import com.flipperdevices.ifrmvp.backend.model.BrandModel
 import com.flipperdevices.ifrmvp.backend.model.CategoryConfiguration
@@ -196,7 +197,7 @@ internal class SignalRouteRegistry(
                     SignalModel(
                         id = it[SignalTable.id].value,
                         remote = SignalModel.FlipperRemote(
-                            name = it[SignalTable.name],
+                            name = "empty",
                             type = it[SignalTable.type],
                             protocol = it[SignalTable.protocol],
                             address = it[SignalTable.address],
@@ -238,13 +239,13 @@ internal class SignalRouteRegistry(
         }
 
         val skippedKeys = transaction(database) {
-            SignalTable
+            SignalNameAliasTable
                 .selectAll()
-                .where { SignalTable.id inList signalRequestModel.skippedResults.map(SignalRequestModel.SignalResultData::signalId) }
+                .where { SignalNameAliasTable.id inList signalRequestModel.skippedResults.map(SignalRequestModel.SignalResultData::signalId) }
                 .mapNotNull {
-                    val keyName = it[SignalTable.name]
+                    val keyName = it[SignalNameAliasTable.signalName]
                     AnyDeviceKeyNamesProvider.getKey(keyName)
-                }
+                }.distinct()
         }
 
         val signalModel = getSignalModel(


### PR DESCRIPTION
### Background
Currently, config by name isn't working as intented, as the signals in signal table qre unique, they don't have name aliases, which is required by configs.
### Changes
This PR adds new table for names aliaes of signals